### PR TITLE
Allow RunGcloud to work with --help.

### DIFF
--- a/driver.py
+++ b/driver.py
@@ -427,13 +427,12 @@ class SDK(object):
     out, err, code = self.RunGcloudRawOutput(
         command, formats, filters, timeout, env)
 
-    # TODO(magimaster): The --help flag doesn't output json.
     if out:
       try:
         return json.loads(out), err, code
       except ValueError:
-        raise error.SDKError('Command [{cmd}] did not return JSON output: '
-                             '{out}'.format(cmd=command, out=out))
+        # TODO(magimaster): Log failure to decode JSON when logging is added
+        return out, err, code
     else:
       return None, err, code
 

--- a/tests/driver_e2e_test.py
+++ b/tests/driver_e2e_test.py
@@ -21,8 +21,6 @@ import os
 import tempfile
 import unittest
 
-import google3
-
 from cloudsdk_test_driver import constants
 from cloudsdk_test_driver import driver
 

--- a/tests/driver_e2e_test.py
+++ b/tests/driver_e2e_test.py
@@ -17,6 +17,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import json
 import os
 import tempfile
 import unittest
@@ -84,6 +85,19 @@ class GcloudTestDriverNoDestroy(unittest.TestCase):
       sdk.RunInitializationCommands()
       _, _, ret = sdk.RunGcloud(['config', 'list'])
       self.assertEqual(0, ret)
+
+
+class GcloudTestDriverHelp(unittest.TestCase):
+
+  def testHelpCommand(self):
+    # The help commands do not return JSON results unlike almost all normal
+    # commands. Verify that they're still handled properly.
+    with driver.Manager():
+      sdk = driver.DefaultSDK()
+      out, _, ret = sdk.RunGcloud(['config', '--help'])
+      self.assertEqual(0, ret)
+      # Just verify that whatever RunGcloud returns is valid as a JSON object.
+      json.dumps(out)
 
 
 if __name__ == '__main__':

--- a/tests/driver_example_test.py
+++ b/tests/driver_example_test.py
@@ -19,8 +19,6 @@ from __future__ import print_function
 
 import unittest
 
-import google3
-
 from cloudsdk_test_driver import driver
 
 

--- a/tests/driver_unit_test.py
+++ b/tests/driver_unit_test.py
@@ -552,6 +552,47 @@ class GcloudTestDriverRunGcloudTest(Base):
         self.sdk, ['gcloud', 'foo', '--format=json'], None, None)
 
 
+class GcloudTestDriverRunGcloudJSONTest(Base):
+
+  def setUp(self):
+    self.MockSDKFactoryDependencies()
+
+    self.sdk = driver.DefaultSDK()
+
+  def PrepareOutput(self, output):
+    self.out = output
+    self.err = 'error'
+    self.code = 0
+
+    self.run_patch = self.StartObjectPatch(
+        driver.SDK, 'RunGcloudRawOutput', return_value=(
+            self.out, self.err, self.code))
+
+  def testRunGcloudJSONOutput(self):
+    self.PrepareOutput("{'a': 'b', 'c': 'd'}")
+
+    out, _, _ = self.sdk.RunGcloud('foo')
+
+    # Verify that the result is valid json
+    json.dumps(out)
+
+  def testRunGcloudStringOutput(self):
+    self.PrepareOutput("not json")
+
+    out, _, _ = self.sdk.RunGcloud('foo')
+
+    # Verify that the result is valid json even though the input wasn'tar
+    json.dumps(out)
+
+  def testRunGcloudEmptyOutput(self):
+    self.PrepareOutput("")
+
+    out, _, _ = self.sdk.RunGcloud('foo')
+
+    # Verify that the result is valid json even though the input wasn'tar
+    json.dumps(out)
+
+
 class GcloudTestDriverErrorTest(Base):
 
   def testError(self):

--- a/tests/driver_unit_test.py
+++ b/tests/driver_unit_test.py
@@ -24,14 +24,12 @@ import random
 import re
 import shutil
 import StringIO
-import subprocess  # Tests are run in google3 so subprocess32 won't get imported
+import subprocess
 import sys
 import tarfile
 import tempfile
 import unittest
 import urllib2
-
-import google3
 
 from cloudsdk_test_driver import _config
 from cloudsdk_test_driver import _sdk_tar

--- a/tests/driver_unit_test.py
+++ b/tests/driver_unit_test.py
@@ -581,7 +581,7 @@ class GcloudTestDriverRunGcloudJSONTest(Base):
 
     out, _, _ = self.sdk.RunGcloud('foo')
 
-    # Verify that the result is valid json even though the input wasn'tar
+    # Verify that the result is valid json even though the input wasn't
     json.dumps(out)
 
   def testRunGcloudEmptyOutput(self):
@@ -589,7 +589,7 @@ class GcloudTestDriverRunGcloudJSONTest(Base):
 
     out, _, _ = self.sdk.RunGcloud('foo')
 
-    # Verify that the result is valid json even though the input wasn'tar
+    # Verify that the result is valid json even though the input wasn't
     json.dumps(out)
 
 


### PR DESCRIPTION
Some commands, including anything with the --help flag, ignore the
--format=json flag and can't be used with RunGcloud as is. (It
expects JSON formatted output and complains otherwise.) This allows
these commands to be used and just returns the full output as a
single string if JSON parsing fails.