### PR TITLE
Add better handling for alternate tar locations.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+**/*.pyc
+**/.cache
+**/__pycache__

--- a/driver.py
+++ b/driver.py
@@ -223,7 +223,9 @@ def Init(tar_location=None, additional_components=None, root_directory=None):
   download_path = _sdk_tar.DownloadTar(tar_location, root_directory)
 
   snapshot_url = _sdk_tar.UnpackTar(download_path, tar_location, root_directory)
-  env = {constants.SNAPSHOT_ENV: snapshot_url}
+  env = {}
+  if snapshot_url:
+    env[constants.SNAPSHOT_ENV] = snapshot_url
 
   if sys.executable:
     env[constants.PYTHON_ENV] = sys.executable

--- a/tests/driver_e2e_test.py
+++ b/tests/driver_e2e_test.py
@@ -100,5 +100,17 @@ class GcloudTestDriverHelp(unittest.TestCase):
       json.dumps(out)
 
 
+class GcloudTestAlternateTar(unittest.TestCase):
+
+  def testInstallPreviousVersion(self):
+    # Make sure the driver can install from one of the archived versions.
+    with driver.Manager(
+        tar_location='https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-140.0.0-linux-x86_64.tar.gz'):
+      sdk = driver.DefaultSDK()
+      sdk.RunInitializationCommands()
+      _, _, ret = sdk.RunGcloud(['config', 'list'])
+      self.assertEqual(0, ret)
+
+
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
Allow the SDK installer to use its own components location if the driver can't find a local copy to override it with.